### PR TITLE
ci: build on both ubuntu and macOS

### DIFF
--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'release-[0-9].[0-9]-*'
+      - 'release-[0-9].[0-9]*'
   pull_request:
     branches:
       - master
-      - 'release-[0-9].[0-9]-*'
+      - 'release-[0-9].[0-9]*'
 
 jobs:
 

--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'release-[0-9].[0-9]'
+      - 'release-[0-9].[0-9]-*'
   pull_request:
     branches:
       - master
-      - 'release-[0-9].[0-9]'
+      - 'release-[0-9].[0-9]-*'
 
 jobs:
 

--- a/.github/workflows/check_and_build.yml
+++ b/.github/workflows/check_and_build.yml
@@ -2,9 +2,13 @@ name: Check & Build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release-[0-9].[0-9]'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release-[0-9].[0-9]'
 
 jobs:
 
@@ -21,17 +25,20 @@ jobs:
 
   make_check_build:
     name: Make Check & Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    
+
     - name: Setup Go environment
       uses: actions/setup-go@v2
       with:
         go-version: '^1.15.0'
-  
+
     - name: Cache Lint Tools
       id: cache-lint-tools
       uses: actions/cache@v2
@@ -41,7 +48,7 @@ jobs:
 
     - name: Check
       run: make check
-      
+
     - name: Build
       run: make build
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Add CI job for building TiCDC on both Ubuntu and macOS.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note

- No release note

<!-- bugfixes or new feature need a release note, must in the form of a list, such as

- owner: add table in batch when start a changefeed to speed up scheduling

or if no need to be included in the release note, just add the following line

- No release note
-->
